### PR TITLE
Feature/responsive pdf

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,6 +11,4 @@ module.system.node.resolve_dirname=src
 <PROJECT_ROOT>/scripts/.*
 <PROJECT_ROOT>/dist/.*
 <PROJECT_ROOT>/node_modules/toyota-style/.*
-
-[libs]
-./decls/
+<PROJECT_ROOT>/node_modules/react-virtualized/.*

--- a/flow-typed/react-virtualized.js
+++ b/flow-typed/react-virtualized.js
@@ -1,0 +1,8 @@
+// react-virtualized only has partial flow types that do not match our version
+declare module "react-virtualized" {
+    declare module.exports: any
+}
+
+declare module "react-virtualized/styles.css" {
+    declare module.exports: any
+}

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
     "react-pdf": "^2.1.7",
     "react-redux": "^5.0.6",
     "react-showdown": "^1.6.0",
+    "react-virtualized": "^9.18.5",
     "redux-actions": "^2.2.1",
-    "stampy": "^0.33.1",
+    "stampy": "^0.37.2",
     "timer-stopwatch": "^0.2.0"
   },
   "peerDependencies": {

--- a/src/component/VideoPlayer.jsx
+++ b/src/component/VideoPlayer.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import type {Element} from 'react';
 import moment from 'moment';
 import PlayerHock from '../hock/PlayerHock';
-import {SpruceClassName, Button} from 'stampy';
+import {Button} from 'obtuse';
+import SpruceClassName from 'stampy/lib/util/SpruceClassName';
 import ProgressBar from './ProgressBar';
 
 type Props = {

--- a/src/exercise/component/Exercise.jsx
+++ b/src/exercise/component/Exercise.jsx
@@ -1,19 +1,38 @@
 //@flow
 import React from 'react';
 import type {Element} from 'react';
+import type {ComponentType} from 'react';
 import {connect} from 'react-redux';
 import {Some} from 'fronads';
 import {Box} from 'obtuse';
 
 import ExerciseActions from '../data/ExerciseActions';
+import ExerciseRecord from '../data/ExerciseRecord';
 import ExerciseNavigation from './ExerciseNavigation';
 const {meta, navigation, interaction, step} = ExerciseActions.exercise;
 
-class ModuleSteps extends React.Component<Object> {
+type Props = {
+    addSteps: Function,
+    actions: Actions,
+    components: Object,
+    navigation: ComponentType<*>,
+    onNext: Function,
+    onScore: Function,
+    onFinish: Function,
+    onPrevious: Function,
+    onGoto: Function,
+    onAnswer: Function,
+    onSetSubmitable: Function,
+    onProgress: Function,
+    steps: Object[],
+    value: ExerciseRecord
+};
+
+class ModuleSteps extends React.Component<Props> {
     static defaultProps = {
         navigation: ExerciseNavigation
     }
-    constructor(props: Object) {
+    constructor(props: Props) {
         super(props);
         const {addSteps, steps, value} = props;
 
@@ -22,52 +41,59 @@ class ModuleSteps extends React.Component<Object> {
         }
     }
     render(): ?Element<*> {
-        const {
+        let {
+            components = {},
             navigation: Navigation,
-            onFinish,
-            onGoto,
             onNext,
-            onPrevious,
-            onProgress,
             onScore,
+            onFinish,
+            onPrevious,
+            onGoto,
             onAnswer,
             onSetSubmitable,
-            value,
-            loader
+            onProgress,
+            value
         } = this.props;
 
-        if(value.steps.size) {
-            const step = value.getIn(['steps', value.step]);
-            const childProps = {
-                value,
-                loader,
-                step,
-                actions: {
-                    onFinish,
-                    onGoto,
-                    onNext,
-                    onPrevious,
-                    onProgress,
-                    onScore,
-                    onAnswer,
-                    onSetSubmitable
-                }
-            };
-
-            const renderableStep = this.props.steps[value.step];
-            if(!renderableStep.render) {
-                console.log('No render method found on', renderableStep);
-            }
-
-            return <Box>
-                <Navigation {...childProps} />
-                <Box modifier="paddingTopMega">
-                    {renderableStep.render(childProps)}
-                </Box>
-            </Box>;
+        if(!value.steps.size) {
+            return null;
         }
 
-        return null;
+        // default components
+        components = {
+            Loader: ({children}) => children || "Loading...",
+            Tick: () => "✔",
+            ...components
+        };
+
+        const step = value.getIn(['steps', value.step]);
+        const childProps = {
+            actions: {
+                onNext,
+                onScore,
+                onFinish,
+                onPrevious,
+                onGoto,
+                onAnswer,
+                onSetSubmitable,
+                onProgress
+            },
+            components,
+            step,
+            value
+        };
+
+        const renderableStep = this.props.steps[value.step];
+        if(!renderableStep.render) {
+            console.log('No render method found on', renderableStep);
+        }
+
+        return <Box>
+            <Navigation {...childProps} />
+            <Box modifier="paddingTopMega">
+                {renderableStep.render(childProps)}
+            </Box>
+        </Box>;
     }
 }
 

--- a/src/exercise/component/Exercise.jsx
+++ b/src/exercise/component/Exercise.jsx
@@ -13,7 +13,6 @@ const {meta, navigation, interaction, step} = ExerciseActions.exercise;
 
 type Props = {
     addSteps: Function,
-    actions: Actions,
     components: Object,
     navigation: ComponentType<*>,
     onNext: Function,

--- a/src/exercise/component/ExerciseModule.jsx
+++ b/src/exercise/component/ExerciseModule.jsx
@@ -11,11 +11,11 @@ import VideoStep from './VideoStep';
 
 type Props = {
     steps: Array<Object>,
+    components?: Object,
     context: Function,
     scorm: {
         masteryScore: number
     },
-    loader: Element<*>,
     [key: string]: *
 };
 
@@ -69,5 +69,8 @@ export default function ExerciseModule(props: Props): Element<*> {
             return step;
         });
 
-    return <Exercise steps={steps} loader={props.loader} />;
+    return <Exercise
+        steps={steps}
+        components={props.components}
+    />;
 }

--- a/src/exercise/component/ExerciseNavigation.jsx
+++ b/src/exercise/component/ExerciseNavigation.jsx
@@ -2,14 +2,20 @@
 import React from 'react';
 import type {Element} from 'react';
 
-import {Box} from 'obtuse';
-import {SpruceClassName} from 'stampy';
+import {Box, Text} from 'obtuse';
 import ExerciseStepRecord from '../data/ExerciseStepRecord';
 
+type Props = {
+    actions: Object,
+    components: Object,
+    value: Object
+};
 
-class ExerciseNavigation extends React.Component<Object> {
+export default class ExerciseNavigation extends React.Component<Props> {
     render(): Element<*> {
         const {value, actions} = this.props;
+        const {Tick} = this.props.components;
+
         return <Box spruceName="ExerciseNavigation">
             {value.steps
                 .map((step: ExerciseStepRecord, index: number): Element<*> => {
@@ -23,13 +29,15 @@ class ExerciseNavigation extends React.Component<Object> {
 
                     return <Box
                         key={index}
+                        modifier={modifier}
                         onClick={complete || previousComplete ? () => actions.onGoto(index) : null}
-                        className={SpruceClassName({name: "ExerciseNavigation_step", modifier})}
-                    >{step.name}</Box>;
+                        spruceName="ExerciseNavigation_step"
+                    >
+                        {step.name}
+                        {complete && <Text> <Tick /></Text>}
+                    </Box>;
                 })
                 .toJS()}
         </Box>;
     }
 }
-
-export default ExerciseNavigation;

--- a/src/exercise/component/PdfStep.js
+++ b/src/exercise/component/PdfStep.js
@@ -3,61 +3,153 @@ import React from 'react';
 import type {Element} from 'react';
 
 import {Document} from 'react-pdf/build/entry.webpack';
+import {List, WindowScroller} from 'react-virtualized';
+import ElementQueryHock from 'stampy/lib/hock/ElementQueryHock';
 import {Page} from 'react-pdf';
 import {Button, Box, Text} from 'obtuse';
+import 'react-virtualized/styles.css'; // move this to sass file
 
-export default class PdfStep extends React.Component<Object, Object> {
+type Props = {
+    components: Object,
+    file: string
+};
+
+type State = {
+    pdf: ?Object,
+    pageRatios?: Map,
+    currentPage: number,
+    loaded: boolean,
+    scale: number
+};
+
+class PdfStep extends React.PureComponent<Props, State> {
     state = {
-        numPages: 0,
+        pdf: null,
+        pageRatios: null,
+        currentPage: 0,
         loaded: false,
-        scale: 1,
-        pageNumber: 0
+        scale: 1
     }
 
-    onDocumentLoad = ({numPages}: Object) => {
-        this.setState({numPages, loaded: true});
+    componentWillReceiveProps(nextProps: Props) {
+        if(this.props.eqWidth !== nextProps.eqWidth) {
+            this.virtualizedListRef && this.virtualizedListRef.recomputeRowHeights();
+        }
     }
+
+    onDocumentLoad = (pdf: Object) => {
+        const promises = Array
+            .from({length: pdf.numPages}, (vv, ii) => ii + 1)
+            .map(pageNumber => pdf.getPage(pageNumber));
+
+        let setPdfState = (values: number[]) => {
+            this.setState({
+                pdf,
+                loaded: true,
+                pageRatios: values
+                    .reduce((map: Map, page: number): Map => {
+                        /* eslint-disable no-unused-vars */
+                        let [x,y,w,h] = page.pageInfo.view;
+                        map.set(page.pageIndex, h/w);
+                        return map;
+                    }, new Map())
+            });
+        };
+
+        if(promises.length === 0) {
+            return;
+        }
+
+        promises[0]
+            .then(value => [value])
+            .then(setPdfState);
+
+        Promise
+            .all(promises)
+            .then(setPdfState);
+    }
+
     onClick = () => {
         const {actions} = this.props;
         actions.onProgress(100);
         actions.onNext();
-    }
+    };
+
     zoom = (value: number) => () => {
-        this.setState(state => ({scale: Math.max(0.4, state.scale + value)}));
-    }
+        let scale = this.state.scale + value;
+        if(scale < 0.4) {
+            return;
+        }
+        this.setState(
+            {scale},
+            () => this.virtualizedListRef.recomputeRowHeights()
+        );
+    };
+
+    rowHeight = ({index}: Object): number => {
+        let {eqWidth} = this.props;
+        let {pageRatios, scale} = this.state;
+        return (pageRatios.get(index) || pageRatios.get(0)) * eqWidth * scale;
+    };
+
+    rowRenderer = ({key, index, style}: Object): Element<*> => {
+        let {eqWidth} = this.props;
+        return <div style={style} key={key}>
+            <Page
+                pdf={this.state.pdf}
+                pageNumber={index + 1}
+                width={eqWidth * this.state.scale}
+            />
+        </div>;
+    };
+
     render(): Element<*> {
-        const {numPages, loaded, scale} = this.state;
-        const {file} = this.props;
+        const {pdf, loaded} = this.state;
+        const {eqWidth, file} = this.props;
+        let {Loader} = this.props.components;
 
         const nextButton = <Text element="div" modifier="marginMega center">
             <Button modifier="sizeMega primary" onClick={this.onClick}>I have read this document</Button>
         </Text>;
+
+        const loading = <Box spruceName="Document_loader"><Loader>Loading PDF...</Loader></Box>;
+
         return <Box>
             <Box modifier="fixed right" style={{zIndex: '1'}}>
                 <Button spruceName="NavigationButton" onClick={this.zoom(0.2)}>+</Button>
                 <Button spruceName="NavigationButton" onClick={this.zoom(-0.2)}>–</Button>
             </Box>
-            <Box className="Document">
+            <Box>
                 <Document
                     file={file}
+                    loading={loading}
                     onLoadSuccess={this.onDocumentLoad}
                 >
-                    {Array.from(
-                        new Array(numPages),
-                        (el, index) => (
-                            <Page
-                                key={`page_${index + 1}`}
-                                className="Document_page"
-                                pageNumber={index + 1}
-                                scale={scale}
-                            >
-                                {this.props.loader}
-                            </Page>
-                        ),
-                    )}
+                    {loaded &&
+                        <WindowScroller>
+                            {({height, isScrolling, onChildScroll, scrollTop}: Object): Element<*> => {
+                                return <List
+                                    autoHeight
+                                    height={height}
+                                    isScrolling={isScrolling}
+                                    onScroll={onChildScroll}
+                                    rowCount={pdf.numPages}
+                                    rowHeight={this.rowHeight}
+                                    overscanRowCount={3}
+                                    rowRenderer={this.rowRenderer}
+                                    scrollTop={scrollTop}
+                                    style={{outline: "none"}}
+                                    width={eqWidth * 2}
+                                    ref={ref => this.virtualizedListRef = ref}
+                                />;
+                            }}
+                        </WindowScroller>
+                    }
                 </Document>
                 {loaded && nextButton}
             </Box>
         </Box>;
     }
 }
+
+export default ElementQueryHock()(PdfStep);

--- a/src/exercise/component/PdfStep.js
+++ b/src/exercise/component/PdfStep.js
@@ -7,7 +7,7 @@ import {List, WindowScroller} from 'react-virtualized';
 import ElementQueryHock from 'stampy/lib/hock/ElementQueryHock';
 import {Page} from 'react-pdf';
 import {Button, Box, Text} from 'obtuse';
-import 'react-virtualized/styles.css'; // move this to sass file
+import 'react-virtualized/styles.css';
 
 type Props = {
     components: Object,

--- a/src/exercise/component/QuizStep.js
+++ b/src/exercise/component/QuizStep.js
@@ -4,9 +4,9 @@ import type {Element} from 'react';
 import Quiz from 'react-markdown-quiz/lib/Quiz';
 import parseMarkdownQuiz from 'react-markdown-quiz/lib/parseMarkdownQuiz';
 import {Box} from 'obtuse';
+import {Button} from 'obtuse';
 import {Text} from 'obtuse';
 import {Wrapper} from 'obtuse';
-import {Button} from 'stampy';
 import Stopwatch from 'timer-stopwatch';
 import moment from 'moment';
 
@@ -85,7 +85,7 @@ export default class QuizStep extends React.Component<Object, Object> {
         actions.onAnswer(batch);
         actions.onProgress(100);
         actions.onNext();
-    }  
+    }
     render(): Element<*> {
         const {step} = this.props;
         const {answeredCount, quiz} = this.state;

--- a/src/exercise/component/VideoStep.js
+++ b/src/exercise/component/VideoStep.js
@@ -64,7 +64,7 @@ export default class VideoStep extends React.Component<Object, Object> {
             </OverlayContent>
         </Overlay>;
 
-        return <Box className="Document">
+        return <Box className="VideoStep">
             <VideoPlayer autoPlay className="VideoStep_videoPlayer" videoRef={(VideoPlayer: *) => { this.videoRef = VideoPlayer; }} src={file} onChange={this.onChange} complete={this.state.complete} >
                 {this.state.complete && nextButton}
             </VideoPlayer>

--- a/src/hock/PlayerHock.jsx
+++ b/src/hock/PlayerHock.jsx
@@ -1,5 +1,5 @@
 //@flow
-import {ConfigureHock} from 'stampy';
+import Hock from 'stampy/lib/util/Hock';
 import React from 'react';
 import type {ElementRef} from 'react';
 import type {Element} from 'react';
@@ -40,8 +40,8 @@ type State = {
     currentTime?: number
 };
 
-export default ConfigureHock(
-    () => (Component) => class PlayerHock extends React.PureComponent<Props, State> {
+export default Hock({
+    hock: () => (Component) => class PlayerHock extends React.PureComponent<Props, State> {
         bufferInterval: *;
         constructor(props: Props) {
             super(props);
@@ -204,4 +204,4 @@ export default ConfigureHock(
             );
         }
     }
-);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,7 +1503,7 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-classnames@^2.2.4, classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -1838,10 +1838,6 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-debounce@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.0.2.tgz#503cc674d8d7f737099664fb75ddbd36b9626dc6"
-
 debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
@@ -1941,6 +1937,10 @@ doctrine@^2.0.2, doctrine@^2.1.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
+
+"dom-helpers@^2.4.0 || ^3.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0:
   version "0.1.0"
@@ -3115,7 +3115,7 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.3:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -3510,7 +3510,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4420,6 +4420,16 @@ react-showdown@^1.6.0:
     prop-types "^15.5.8"
     showdown "^1.5.0"
 
+react-virtualized@^9.18.0:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
+  dependencies:
+    babel-runtime "^6.26.0"
+    classnames "^2.2.3"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    loose-envify "^1.3.0"
+    prop-types "^15.6.0"
+
 react@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
@@ -4924,25 +4934,6 @@ stampy@^0.30.0:
     react-select "^1.0.0-rc.4"
     url-search-params "^0.7.0"
 
-stampy@^0.33.1:
-  version "0.33.1"
-  resolved "https://registry.yarnpkg.com/stampy/-/stampy-0.33.1.tgz#e53da9c58a75c000ac5f1d8e54dcb08817f1aa35"
-  dependencies:
-    bruce "^0.9.0"
-    classnames "^2.2.5"
-    debounce "^1.0.2"
-    element-resize-detector "^1.1.12"
-    immutable "^3.8.1"
-    is-plain-object "^2.0.3"
-    lru-memoize "^1.0.2"
-    moment "^2.18.1"
-    numeral "^2.0.6"
-    prop-types "^15.5.8"
-    proxyquire "^1.7.11"
-    react-immutable-proptypes "^2.1.0"
-    react-select "^1.0.0-rc.4"
-    url-search-params "^0.9.0"
-
 stampy@^0.34.0:
   version "0.34.0"
   resolved "https://registry.yarnpkg.com/stampy/-/stampy-0.34.0.tgz#0cc642bcffc36cacf3f17a0c7f250041c512b38c"
@@ -4950,6 +4941,16 @@ stampy@^0.34.0:
     classnames "^2.2.5"
     element-resize-detector "^1.1.12"
     is-plain-object "^2.0.3"
+    url-search-params "^0.9.0"
+
+stampy@^0.37.2:
+  version "0.37.2"
+  resolved "https://registry.yarnpkg.com/stampy/-/stampy-0.37.2.tgz#c1582c6d09e62c09c050d7fc415eddeb63f34a02"
+  dependencies:
+    classnames "^2.2.5"
+    element-resize-detector "^1.1.12"
+    is-plain-object "^2.0.3"
+    unmutable "^0.19.0"
     url-search-params "^0.9.0"
 
 stream-browserify@^2.0.1:
@@ -5290,6 +5291,13 @@ unique-temp-dir@^1.0.0:
     mkdirp "^0.5.1"
     os-tmpdir "^1.0.1"
     uid2 "0.0.3"
+
+unmutable@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.19.2.tgz#d62d90f5630f4685e8eac9da06c6b78aa068b626"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    is-plain-object "^2.0.4"
 
 unzip-response@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4420,7 +4420,7 @@ react-showdown@^1.6.0:
     prop-types "^15.5.8"
     showdown "^1.5.0"
 
-react-virtualized@^9.18.0:
+react-virtualized@^9.18.5:
   version "9.18.5"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
   dependencies:


### PR DESCRIPTION
Bad commit messages.

- PDF Step improvements
  - PDF rendering now has virtualized pages with `react-virtualized`
  - Panning is permitted when zoomed
  - Initial scale is set by initial browser width
  - Scroll position is translated when zooming so that you're still looking at the same page
- Updated stampy
- Make navigation buttons stack on mobile. Might be nice to use a select but eh.
- Add PdfStep and VideoStep spruce names
- Pass down a `components` prop, rather than `loader`, that can contains components to render `Tick` and `Loader`. Defaults will be used if some aren't provided.

## Upgrade notes
- You will need to @include `PdfStep` and `VideoStep` in your module builder. See https://github.com/blueflag/mitsubishi-style/pull/37 for an example of CSS for those components
- If you're passing `loader` into the `<Component>` in your `render.js`, replace this with a `components` prop with a key of `Loader`.

e.g.
```
<Provider store={store}>
    <Component {...moduleConfig} loader={<CoolLoader />} />
</Provider>
```

goes to

```
<Provider store={store}>
    <Component {...moduleConfig} components={{Loader: CoolLoader}} />
</Provider>
```